### PR TITLE
Add caching for repeated compliance checks

### DIFF
--- a/hardening-compliance-check.sh
+++ b/hardening-compliance-check.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # hardening-compliance-check.sh - Linux Hardening Compliance Checker
-# 
+#
 # A comprehensive security compliance checker that validates Linux systems
 # against industry-standard hardening benchmarks including CIS benchmarks.
 #
@@ -17,6 +17,10 @@
 #   --no-color          Disable colored output
 #   --list-categories   List available check categories
 #   --list-checks       List all available checks
+#   --cache             Enable caching of check results
+#   --no-cache          Disable caching (default)
+#   --clear-cache       Clear the cache and exit
+#   --cache-ttl SECS    Set cache time-to-live in seconds (default: 3600)
 #
 
 set -euo pipefail
@@ -36,6 +40,7 @@ QUIET_MODE=false
 NO_COLOR=false
 SELECTED_CATEGORY=""
 START_TIME=""
+CACHE_TTL="$DEFAULT_CACHE_TTL"
 
 # Print usage information
 usage() {
@@ -57,7 +62,11 @@ OPTIONS:
     -q, --quiet         Suppress non-essential output
     --no-color          Disable colored output
     --list-categories   List available check categories
-    --list-checks       List all available checks with descriptions
+    --list-checks       List all available checks
+    --cache             Enable caching of check results
+    --no-cache          Disable caching (default)
+    --clear-cache       Clear the cache and exit
+    --cache-ttl SECS    Set cache time-to-live in seconds (default: 3600)
 
 EXAMPLES:
     # Run all checks
@@ -69,8 +78,14 @@ EXAMPLES:
     # Output results to JSON file
     ${SCRIPT_NAME} -f json -o results.json
 
-    # Run with quiet mode
-    ${SCRIPT_NAME} -q
+    # Run with caching enabled (faster repeated runs)
+    ${SCRIPT_NAME} --cache
+
+    # Clear the cache
+    ${SCRIPT_NAME} --clear-cache
+
+    # Run with custom cache TTL (5 minutes)
+    ${SCRIPT_NAME} --cache --cache-ttl 300
 
 EXIT CODES:
     0   All checks passed (compliant)
@@ -82,6 +97,7 @@ NOTES:
     - This script should be run as root for complete system access
     - Some checks may be distribution-specific
     - Results are based on CIS Benchmark recommendations
+    - Cache is stored in: ${CACHE_DIR}
 
 EOF
 }
@@ -98,26 +114,26 @@ print_version() {
 # List available categories
 list_categories() {
     print_header "AVAILABLE CHECK CATEGORIES"
-    
+
     for key in "${!CATEGORIES[@]}"; do
         local name="${CATEGORIES[$key]}"
         printf "  %-25s %s\n" "$key" "- $name"
     done
-    
+
     echo ""
 }
 
 # List all available checks
 list_checks() {
     print_header "AVAILABLE SECURITY CHECKS"
-    
+
     echo "SSH Configuration Checks:"
     for key in "${!SSH_BENCHMARKS[@]}"; do
         local expected="${SSH_BENCHMARKS[$key]}"
         local severity="${SSH_SEVERITY[$key]}"
         printf "  %-30s (expected: %-15s severity: %s)\n" "$key" "$expected" "$severity"
     done
-    
+
     echo ""
     echo "Kernel Parameter Checks:"
     for param in "${!KERNEL_BENCHMARKS[@]}"; do
@@ -125,7 +141,7 @@ list_checks() {
         local severity="${KERNEL_SEVERITY[$param]}"
         printf "  %-40s = %-5s [%s]\n" "$param" "$expected" "$severity"
     done
-    
+
     echo ""
     echo "File Permission Checks:"
     for file in "${!FILE_PERM_BENCHMARKS[@]}"; do
@@ -133,26 +149,26 @@ list_checks() {
         local severity="${FILE_PERM_SEVERITY[$file]}"
         printf "  %-35s %s [%s]\n" "$file" "$expected" "$severity"
     done
-    
+
     echo ""
     echo "Password Policy Checks:"
     for key in "${!PASSWORD_BENCHMARKS[@]}"; do
         local expected="${PASSWORD_BENCHMARKS[$key]}"
         printf "  %-20s %s\n" "$key" "$expected"
     done
-    
+
     echo ""
     echo "Disabled Services:"
     for service in "${DISABLED_SERVICES[@]}"; do
         printf "  %s\n" "$service"
     done
-    
+
     echo ""
     echo "Enabled Services:"
     for service in "${ENABLED_SERVICES[@]}"; do
         printf "  %s\n" "$service"
     done
-    
+
     echo ""
 }
 
@@ -211,6 +227,32 @@ parse_args() {
                 list_checks
                 exit $EXIT_SUCCESS
                 ;;
+            --cache)
+                USE_CACHE=true
+                shift
+                ;;
+            --no-cache)
+                USE_CACHE=false
+                shift
+                ;;
+            --clear-cache)
+                clear_cache
+                exit $EXIT_SUCCESS
+                ;;
+            --cache-ttl)
+                if [[ -n "${2:-}" ]]; then
+                    if [[ "$2" =~ ^[0-9]+$ ]]; then
+                        CACHE_TTL="$2"
+                        shift 2
+                    else
+                        log_error "Cache TTL must be a positive integer"
+                        exit $EXIT_FAILURE
+                    fi
+                else
+                    log_error "Cache TTL argument requires a value"
+                    exit $EXIT_FAILURE
+                fi
+                ;;
             *)
                 log_error "Unknown option: $1"
                 usage
@@ -255,10 +297,10 @@ generate_json_output() {
     local fail_count="$2"
     local skip_count="$3"
     local total="$4"
-    
+
     local timestamp
     timestamp=$(date -Iseconds)
-    
+
     cat << EOF
 {
     "report": {
@@ -286,7 +328,7 @@ generate_csv_output() {
     local pass_count="$1"
     local fail_count="$2"
     local skip_count="$3"
-    
+
     echo "metric,value"
     echo "timestamp,$(date -Iseconds)"
     echo "hostname,$(hostname)"
@@ -303,7 +345,7 @@ generate_csv_output() {
 run_category_checks() {
     local category="$1"
     local result
-    
+
     case "$category" in
         file_permissions)
             check_file_permissions
@@ -338,60 +380,60 @@ run_category_checks() {
             return $EXIT_FAILURE
             ;;
     esac
-    
+
     return $result
 }
 
 # Main function
 main() {
     START_TIME=$(date +%s)
-    
+
     # Parse command line arguments
     parse_args "$@"
-    
+
     # Handle no-color option
     if [[ "$NO_COLOR" == true ]]; then
         exec 3>&1
         exec > >(sed 's/\x1b\[[0-9;]*m//g')
     fi
-    
+
     # Validate inputs
     if ! validate_format; then
         exit $EXIT_FAILURE
     fi
-    
+
     if ! validate_category; then
         exit $EXIT_FAILURE
     fi
-    
+
     # Check if running as root (warn but don't fail)
     if [[ $EUID -ne 0 ]]; then
         log_warning "Running as non-root user. Some checks may be skipped."
         log_warning "For complete results, run as root."
         echo ""
     fi
-    
+
     # Run checks
     local exit_code
-    
+
     if [[ -n "$SELECTED_CATEGORY" ]]; then
         print_header "LINUX HARDENING COMPLIANCE CHECK"
         echo "  Category: ${CATEGORIES[$SELECTED_CATEGORY]}"
         echo "  Started: $(timestamp)"
         echo ""
-        
+
         run_category_checks "$SELECTED_CATEGORY"
         exit_code=$?
     else
         run_all_checks
         exit_code=$?
     fi
-    
+
     # Calculate duration
     local end_time duration
     end_time=$(date +%s)
     duration=$((end_time - START_TIME))
-    
+
     # Generate output file if specified
     if [[ -n "$OUTPUT_FILE" ]]; then
         case "$OUTPUT_FORMAT" in
@@ -407,11 +449,11 @@ main() {
                 ;;
         esac
     fi
-    
+
     # Print completion message
     echo ""
     log_info "Completed in $(format_duration $duration)"
-    
+
     exit $exit_code
 }
 

--- a/lib/checks.sh
+++ b/lib/checks.sh
@@ -4,6 +4,49 @@
 # Implements individual security checks against defined benchmarks
 #
 
+# Global cache control
+USE_CACHE=false
+CACHE_HIT_COUNT=0
+CACHE_MISS_COUNT=0
+
+# Enable caching
+enable_cache() {
+    USE_CACHE=true
+}
+
+# Disable caching
+disable_cache() {
+    USE_CACHE=false
+}
+
+# Get cached check result or execute check
+# Args: check_name, check_function, [args...]
+# Returns: check result status
+run_check_with_cache() {
+    local check_name="$1"
+    local check_function="$2"
+    shift 2
+
+    if [[ "$USE_CACHE" == true ]] && is_cache_valid; then
+        local cached_result
+        cached_result=$(get_cached_result "$check_name")
+
+        if [[ -n "$cached_result" ]]; then
+            local cached_details
+            cached_details=$(get_cached_details "$check_name")
+            ((CACHE_HIT_COUNT++))
+            echo "$cached_result|$cached_details"
+            return 0
+        fi
+    fi
+
+    ((CACHE_MISS_COUNT++))
+    # Execute the check function and capture result
+    local result
+    result=$($check_function "$@")
+    echo "$result"
+}
+
 # Get SSH parameter type for validation
 get_ssh_param_type() {
     local param="$1"
@@ -215,9 +258,9 @@ check_file_permissions() {
 check_empty_passwords() {
     print_subheader "Empty Password Check"
     echo ""
-    
+
     local empty_pass_users=0
-    
+
     if [[ -f /etc/shadow ]]; then
         while IFS=: read -r username password rest; do
             if [[ "$password" == "" || "$password" == "!" || "$password" == "*" ]]; then
@@ -229,7 +272,7 @@ check_empty_passwords() {
             fi
         done < /etc/shadow
     fi
-    
+
     if [[ $empty_pass_users -eq 0 ]]; then
         print_check_result "No empty passwords" "pass"
         echo ""
@@ -245,15 +288,15 @@ check_empty_passwords() {
 check_uid_zero_users() {
     print_subheader "UID 0 User Check"
     echo ""
-    
+
     local uid_zero_users=()
-    
+
     while IFS=: read -r username _ uid rest; do
         if [[ "$uid" == "0" && "$username" != "root" ]]; then
             uid_zero_users+=("$username")
         fi
     done < /etc/passwd
-    
+
     if [[ ${#uid_zero_users[@]} -eq 0 ]]; then
         print_check_result "No non-root UID 0 users" "pass"
         echo ""
@@ -334,10 +377,10 @@ check_dangerous_services() {
     local pass_count=0
     local fail_count=0
     local skip_count=0
-    
+
     print_subheader "Dangerous Service Checks"
     echo ""
-    
+
     for service in "${DISABLED_SERVICES[@]}"; do
         if service_enabled "$service" || service_active "$service"; then
             print_check_result "Service $service disabled" "fail" "Service is active/enabled"
@@ -347,10 +390,10 @@ check_dangerous_services() {
             ((pass_count++))
         fi
     done
-    
+
     echo ""
     log_info "Service checks: $pass_count passed, $fail_count failed"
-    
+
     if [[ $fail_count -gt 0 ]]; then
         return $EXIT_FAILURE
     fi
@@ -361,10 +404,10 @@ check_dangerous_services() {
 check_required_services() {
     local pass_count=0
     local fail_count=0
-    
+
     print_subheader "Required Service Checks"
     echo ""
-    
+
     for service in "${ENABLED_SERVICES[@]}"; do
         if command_exists systemctl; then
             if service_enabled "$service" || service_active "$service"; then
@@ -378,10 +421,10 @@ check_required_services() {
             print_check_result "Service $service" "skip" "systemctl not available"
         fi
     done
-    
+
     echo ""
     log_info "Required services: $pass_count passed, $fail_count warnings"
-    
+
     return $EXIT_SUCCESS
 }
 
@@ -389,10 +432,10 @@ check_required_services() {
 check_cron_at_restrictions() {
     local pass_count=0
     local fail_count=0
-    
+
     print_subheader "Cron/At Access Control Checks"
     echo ""
-    
+
     # Check cron.allow exists or cron.deny doesn't exist
     if [[ -f "$CRON_ALLOW" ]]; then
         print_check_result "Cron access restricted" "pass" "cron.allow exists"
@@ -404,7 +447,7 @@ check_cron_at_restrictions() {
         print_check_result "Cron access restricted" "fail" "No cron.allow file"
         ((fail_count++))
     fi
-    
+
     # Check at.allow exists or at.deny doesn't exist
     if [[ -f "$AT_ALLOW" ]]; then
         print_check_result "At access restricted" "pass" "at.allow exists"
@@ -416,10 +459,10 @@ check_cron_at_restrictions() {
         print_check_result "At access restricted" "fail" "No at.allow file"
         ((fail_count++))
     fi
-    
+
     echo ""
     log_info "Access control: $pass_count passed, $fail_count failed"
-    
+
     if [[ $fail_count -gt 0 ]]; then
         return $EXIT_FAILURE
     fi
@@ -431,12 +474,12 @@ check_world_writable() {
     local pass_count=0
     local fail_count=0
     local world_writable_files=()
-    
+
     print_subheader "World-Writable File Checks"
     echo ""
-    
+
     local system_dirs=("/etc" "/usr" "/bin" "/sbin" "/lib" "/boot")
-    
+
     for dir in "${system_dirs[@]}"; do
         if [[ -d "$dir" ]]; then
             while IFS= read -r -d '' file; do
@@ -444,7 +487,7 @@ check_world_writable() {
             done < <(find "$dir" -type f -perm -0002 -print0 2>/dev/null | head -z -n 20)
         fi
     done
-    
+
     if [[ ${#world_writable_files[@]} -eq 0 ]]; then
         print_check_result "No world-writable system files" "pass"
         ((pass_count++))
@@ -458,10 +501,10 @@ check_world_writable() {
             echo "    ... and $((${#world_writable_files[@]} - 5)) more"
         fi
     fi
-    
+
     echo ""
     log_info "World-writable check: $pass_count passed, $fail_count failed"
-    
+
     if [[ $fail_count -gt 0 ]]; then
         return $EXIT_FAILURE
     fi
@@ -473,12 +516,12 @@ check_unowned_files() {
     local pass_count=0
     local fail_count=0
     local unowned_files=()
-    
+
     print_subheader "Unowned File Checks"
     echo ""
-    
+
     local check_dirs=("/etc" "/usr" "/bin" "/sbin")
-    
+
     for dir in "${check_dirs[@]}"; do
         if [[ -d "$dir" ]]; then
             while IFS= read -r -d '' file; do
@@ -486,7 +529,7 @@ check_unowned_files() {
             done < <(find "$dir" -type f \( -nouser -o -nogroup \) -print0 2>/dev/null | head -z -n 20)
         fi
     done
-    
+
     if [[ ${#unowned_files[@]} -eq 0 ]]; then
         print_check_result "No unowned system files" "pass"
         ((pass_count++))
@@ -500,10 +543,10 @@ check_unowned_files() {
             echo "    ... and $((${#unowned_files[@]} - 5)) more"
         fi
     fi
-    
+
     echo ""
     log_info "Unowned file check: $pass_count passed, $fail_count failed"
-    
+
     if [[ $fail_count -gt 0 ]]; then
         return $EXIT_FAILURE
     fi
@@ -514,11 +557,11 @@ check_unowned_files() {
 check_audit_status() {
     print_subheader "Audit Daemon Check"
     echo ""
-    
+
     if command_exists auditctl; then
         local status
         status=$(auditctl -s 2>/dev/null)
-        
+
         if [[ -n "$status" ]]; then
             print_check_result "Audit daemon running" "pass"
             echo ""
@@ -540,12 +583,12 @@ check_suid_sgid() {
     local pass_count=0
     local fail_count=0
     local suid_files=()
-    
+
     print_subheader "SUID/SGID Binary Checks"
     echo ""
-    
+
     local non_standard_dirs=("/tmp" "/var/tmp" "/home" "/opt")
-    
+
     for dir in "${non_standard_dirs[@]}"; do
         if [[ -d "$dir" ]]; then
             while IFS= read -r -d '' file; do
@@ -553,7 +596,7 @@ check_suid_sgid() {
             done < <(find "$dir" -type f \( -perm -4000 -o -perm -2000 \) -print0 2>/dev/null | head -z -n 20)
         fi
     done
-    
+
     if [[ ${#suid_files[@]} -eq 0 ]]; then
         print_check_result "No SUID/SGID in non-standard dirs" "pass"
         ((pass_count++))
@@ -567,10 +610,10 @@ check_suid_sgid() {
             echo "    ... and $((${#suid_files[@]} - 5)) more"
         fi
     fi
-    
+
     echo ""
     log_info "SUID/SGID check: $pass_count passed, $fail_count warnings"
-    
+
     return $EXIT_SUCCESS
 }
 
@@ -580,14 +623,19 @@ run_all_checks() {
     local total_fail=0
     local total_skip=0
     local result
-    
+
+    # Initialize cache if enabled
+    if [[ "$USE_CACHE" == true ]]; then
+        write_cache_header
+    fi
+
     print_header "LINUX HARDENING COMPLIANCE CHECK"
     echo "  Started: $(timestamp)"
     echo "  Hostname: $(hostname)"
     echo "  Distribution: $(get_distribution) $(get_distribution_version)"
     echo "  Kernel: $(uname -r)"
     echo ""
-    
+
     # File permissions
     print_header "FILE PERMISSIONS"
     check_file_permissions
@@ -597,7 +645,7 @@ run_all_checks() {
         1) ((total_fail++)) ;;
         *) ((total_skip++)) ;;
     esac
-    
+
     # User accounts
     print_header "USER ACCOUNT SECURITY"
     check_empty_passwords
@@ -607,7 +655,7 @@ run_all_checks() {
         1) ((total_fail++)) ;;
         *) ((total_skip++)) ;;
     esac
-    
+
     check_uid_zero_users
     result=$?
     case $result in
@@ -615,7 +663,7 @@ run_all_checks() {
         1) ((total_fail++)) ;;
         *) ((total_skip++)) ;;
     esac
-    
+
     check_password_policy
     result=$?
     case $result in
@@ -623,7 +671,7 @@ run_all_checks() {
         1) ((total_fail++)) ;;
         *) ((total_skip++)) ;;
     esac
-    
+
     # SSH hardening
     print_header "SSH HARDENING"
     check_ssh_config
@@ -633,7 +681,7 @@ run_all_checks() {
         1) ((total_fail++)) ;;
         *) ((total_skip++)) ;;
     esac
-    
+
     # Kernel hardening
     print_header "KERNEL HARDENING"
     check_kernel_params
@@ -643,7 +691,7 @@ run_all_checks() {
         1) ((total_fail++)) ;;
         *) ((total_skip++)) ;;
     esac
-    
+
     # Service hardening
     print_header "SERVICE HARDENING"
     check_dangerous_services
@@ -653,7 +701,7 @@ run_all_checks() {
         1) ((total_fail++)) ;;
         *) ((total_skip++)) ;;
     esac
-    
+
     check_required_services
     result=$?
     case $result in
@@ -661,7 +709,7 @@ run_all_checks() {
         1) ((total_fail++)) ;;
         *) ((total_skip++)) ;;
     esac
-    
+
     check_cron_at_restrictions
     result=$?
     case $result in
@@ -669,7 +717,7 @@ run_all_checks() {
         1) ((total_fail++)) ;;
         *) ((total_skip++)) ;;
     esac
-    
+
     # Additional security checks
     print_header "ADDITIONAL SECURITY CHECKS"
     check_world_writable
@@ -679,7 +727,7 @@ run_all_checks() {
         1) ((total_fail++)) ;;
         *) ((total_skip++)) ;;
     esac
-    
+
     check_unowned_files
     result=$?
     case $result in
@@ -687,7 +735,7 @@ run_all_checks() {
         1) ((total_fail++)) ;;
         *) ((total_skip++)) ;;
     esac
-    
+
     check_suid_sgid
     result=$?
     case $result in
@@ -695,7 +743,7 @@ run_all_checks() {
         1) ((total_fail++)) ;;
         *) ((total_skip++)) ;;
     esac
-    
+
     check_audit_status
     result=$?
     case $result in
@@ -703,7 +751,7 @@ run_all_checks() {
         1) ((total_fail++)) ;;
         *) ((total_skip++)) ;;
     esac
-    
+
     # Summary
     print_header "COMPLIANCE SUMMARY"
     local total=$((total_pass + total_fail + total_skip))
@@ -711,7 +759,7 @@ run_all_checks() {
     if [[ $total -gt 0 ]]; then
         pass_pct=$(( (total_pass * 100) / total ))
     fi
-    
+
     echo "  Total checks:  $total"
     print_color "$COLOR_GREEN" "  Passed:        $total_pass"
     print_color "$COLOR_RED" "  Failed:        $total_fail"
@@ -719,7 +767,16 @@ run_all_checks() {
     echo ""
     echo "  Compliance score: ${pass_pct}%"
     echo ""
-    
+
+    # Report cache statistics if caching was used
+    if [[ "$USE_CACHE" == true ]]; then
+        if [[ $CACHE_HIT_COUNT -gt 0 || $CACHE_MISS_COUNT -gt 0 ]]; then
+            echo "  Cache hits:    $CACHE_HIT_COUNT"
+            echo "  Cache misses:  $CACHE_MISS_COUNT"
+            echo ""
+        fi
+    fi
+
     if [[ $total_fail -eq 0 ]]; then
         print_color "$COLOR_GREEN" "  Status: COMPLIANT"
         return $EXIT_SUCCESS

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -19,6 +19,12 @@ readonly CRON_DENY="/etc/cron.deny"
 readonly AT_ALLOW="/etc/at.allow"
 readonly AT_DENY="/etc/at.deny"
 
+# Cache configuration
+readonly CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/hardening-compliance-check"
+readonly CACHE_FILE="${CACHE_DIR}/check_results.cache"
+readonly CACHE_VERSION="1"
+DEFAULT_CACHE_TTL=3600  # 1 hour in seconds
+
 # Benchmark severity levels
 readonly SEVERITY_CRITICAL="critical"
 readonly SEVERITY_HIGH="high"

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -69,7 +69,7 @@ print_check_result() {
     local check_name="$1"
     local status="$2"
     local details="${3:-}"
-    
+
     local status_color status_icon
     case "$status" in
         pass)
@@ -93,13 +93,13 @@ print_check_result() {
             status_icon="?"
             ;;
     esac
-    
+
     if supports_color; then
         printf "  ${status_color}[%s]${COLOR_RESET} %-50s" "$status_icon" "$check_name"
     else
         printf "  [%s] %-50s" "$status_icon" "$check_name"
     fi
-    
+
     if [[ -n "$details" ]]; then
         echo " - $details"
     else
@@ -113,11 +113,11 @@ print_header() {
     local width=60
     local padding=$(( (width - ${#title}) / 2 ))
     local line=""
-    
+
     for ((i=0; i<width; i++)); do
         line+="="
     done
-    
+
     echo ""
     if supports_color; then
         echo -e "${COLOR_BOLD}${COLOR_CYAN}${line}${COLOR_RESET}"
@@ -230,7 +230,7 @@ check_sysctl() {
     local expected="$2"
     local current
     current=$(get_sysctl "$param")
-    
+
     if [[ "$current" == "$expected" ]]; then
         return 0
     fi
@@ -242,7 +242,7 @@ get_config_value() {
     local file="$1"
     local key="$2"
     local separator="${3:- }"
-    
+
     if [[ -f "$file" ]]; then
         grep -E "^[[:space:]]*${key}${separator}" "$file" 2>/dev/null | \
             sed -E "s/^[[:space:]]*${key}${separator}//" | \
@@ -256,11 +256,11 @@ config_has_value() {
     local key="$2"
     local value="$3"
     local separator="${4:- }"
-    
+
     if [[ ! -f "$file" ]]; then
         return 1
     fi
-    
+
     local current
     current=$(get_config_value "$file" "$key" "$separator")
     [[ "$current" == "$value" ]]
@@ -270,11 +270,11 @@ config_has_value() {
 config_key_exists() {
     local file="$1"
     local key="$2"
-    
+
     if [[ ! -f "$file" ]]; then
         return 1
     fi
-    
+
     grep -qE "^[[:space:]]*${key}[[:space:]]" "$file" 2>/dev/null
 }
 
@@ -316,6 +316,11 @@ ends_with() {
 # Get current timestamp
 timestamp() {
     date '+%Y-%m-%d %H:%M:%S'
+}
+
+# Get current timestamp in seconds since epoch
+timestamp_epoch() {
+    date '+%s'
 }
 
 # Get distribution info
@@ -541,4 +546,201 @@ log_validation_error() {
     local value="$2"
     local reason="${3:-invalid value}"
     log_warning "Validation failed for '$param': $reason (got: '$value')"
+}
+
+# ============================================================================
+# Cache Functions
+# ============================================================================
+
+# Initialize cache directory
+# Returns 0 on success, 1 on failure
+init_cache() {
+    if [[ ! -d "$CACHE_DIR" ]]; then
+        mkdir -p "$CACHE_DIR" 2>/dev/null
+        if [[ $? -ne 0 ]]; then
+            log_warning "Failed to create cache directory: $CACHE_DIR"
+            return 1
+        fi
+    fi
+    return 0
+}
+
+# Check if cache is enabled and valid
+# Returns 0 if cache should be used, 1 otherwise
+is_cache_valid() {
+    local cache_ttl="${1:-$DEFAULT_CACHE_TTL}"
+
+    if [[ ! -f "$CACHE_FILE" ]]; then
+        return 1
+    fi
+
+    local cache_age
+    local current_time
+    current_time=$(timestamp_epoch)
+    cache_age=$(get_cache_age)
+
+    if [[ -z "$cache_age" ]]; then
+        return 1
+    fi
+
+    local age=$((current_time - cache_age))
+    if [[ $age -lt $cache_ttl ]]; then
+        return 0
+    fi
+
+    return 1
+}
+
+# Get cache age in seconds since epoch
+# Returns empty string if cache doesn't exist or is invalid
+get_cache_age() {
+    if [[ ! -f "$CACHE_FILE" ]]; then
+        echo ""
+        return
+    fi
+
+    local meta_line
+    meta_line=$(grep "^#CACHE_META:" "$CACHE_FILE" 2>/dev/null | head -1)
+    if [[ -z "$meta_line" ]]; then
+        echo ""
+        return
+    fi
+
+    echo "$meta_line" | sed 's/^#CACHE_META://' | cut -d'|' -f1
+}
+
+# Get cache version
+get_cache_version() {
+    if [[ ! -f "$CACHE_FILE" ]]; then
+        echo ""
+        return
+    fi
+
+    local meta_line
+    meta_line=$(grep "^#CACHE_META:" "$CACHE_FILE" 2>/dev/null | head -1)
+    if [[ -z "$meta_line" ]]; then
+        echo ""
+        return
+    fi
+
+    echo "$meta_line" | sed 's/^#CACHE_META://' | cut -d'|' -f2
+}
+
+# Get cached result for a specific check
+# Args: check_name
+# Returns: cached result (pass|fail|skip|warn) or empty if not found
+get_cached_result() {
+    local check_name="$1"
+
+    if [[ ! -f "$CACHE_FILE" ]]; then
+        echo ""
+        return
+    fi
+
+    local result_line
+    result_line=$(grep "^${check_name}|" "$CACHE_FILE" 2>/dev/null | head -1)
+    if [[ -z "$result_line" ]]; then
+        echo ""
+        return
+    fi
+
+    echo "$result_line" | cut -d'|' -f2
+}
+
+# Get cached details for a specific check
+# Args: check_name
+# Returns: cached details or empty if not found
+get_cached_details() {
+    local check_name="$1"
+
+    if [[ ! -f "$CACHE_FILE" ]]; then
+        echo ""
+        return
+    fi
+
+    local result_line
+    result_line=$(grep "^${check_name}|" "$CACHE_FILE" 2>/dev/null | head -1)
+    if [[ -z "$result_line" ]]; then
+        echo ""
+        return
+    fi
+
+    echo "$result_line" | cut -d'|' -f3-
+}
+
+# Store result in cache
+# Args: check_name, status, details
+store_cache_result() {
+    local check_name="$1"
+    local status="$2"
+    local details="${3:-}"
+
+    if [[ ! -d "$CACHE_DIR" ]]; then
+        init_cache || return 1
+    fi
+
+    # Remove old entry for this check if exists
+    if [[ -f "$CACHE_FILE" ]]; then
+        local temp_file="${CACHE_FILE}.tmp"
+        grep -v "^${check_name}|" "$CACHE_FILE" > "$temp_file" 2>/dev/null || true
+        mv "$temp_file" "$CACHE_FILE" 2>/dev/null || true
+    fi
+
+    # Append new entry
+    echo "${check_name}|${status}|${details}" >> "$CACHE_FILE" 2>/dev/null
+}
+
+# Write cache metadata header
+# Should be called before storing results
+write_cache_header() {
+    local current_time
+    current_time=$(timestamp_epoch)
+
+    if [[ ! -d "$CACHE_DIR" ]]; then
+        init_cache || return 1
+    fi
+
+    # Create new cache file with header
+    echo "#CACHE_META:${current_time}|${CACHE_VERSION}" > "$CACHE_FILE" 2>/dev/null
+    echo "# Generated: $(timestamp)" >> "$CACHE_FILE" 2>/dev/null
+    echo "# Hostname: $(hostname)" >> "$CACHE_FILE" 2>/dev/null
+    echo "# Distribution: $(get_distribution) $(get_distribution_version)" >> "$CACHE_FILE" 2>/dev/null
+    echo "# Kernel: $(uname -r)" >> "$CACHE_FILE" 2>/dev/null
+    echo "" >> "$CACHE_FILE" 2>/dev/null
+}
+
+# Clear the cache
+clear_cache() {
+    if [[ -f "$CACHE_FILE" ]]; then
+        rm -f "$CACHE_FILE" 2>/dev/null
+        if [[ $? -eq 0 ]]; then
+            log_info "Cache cleared"
+            return 0
+        else
+            log_error "Failed to clear cache"
+            return 1
+        fi
+    else
+        log_info "No cache to clear"
+        return 0
+    fi
+}
+
+# Get cache file path
+get_cache_path() {
+    echo "$CACHE_FILE"
+}
+
+# Check if cache is empty (only has header)
+is_cache_empty() {
+    if [[ ! -f "$CACHE_FILE" ]]; then
+        return 0
+    fi
+
+    local data_lines
+    data_lines=$(grep -v "^#" "$CACHE_FILE" 2>/dev/null | grep -v "^$" | wc -l)
+    if [[ $data_lines -eq 0 ]]; then
+        return 0
+    fi
+    return 1
 }

--- a/tests/test_runner.sh
+++ b/tests/test_runner.sh
@@ -49,9 +49,9 @@ assert_equals() {
     local expected="$1"
     local actual="$2"
     local message="${3:-}"
-    
+
     ((TESTS_RUN++))
-    
+
     if [[ "$expected" == "$actual" ]]; then
         ((TESTS_PASSED++))
         if [[ "$VERBOSE" == true ]]; then
@@ -72,9 +72,9 @@ assert_not_equals() {
     local expected="$1"
     local actual="$2"
     local message="${3:-}"
-    
+
     ((TESTS_RUN++))
-    
+
     if [[ "$expected" != "$actual" ]]; then
         ((TESTS_PASSED++))
         if [[ "$VERBOSE" == true ]]; then
@@ -94,9 +94,9 @@ assert_not_equals() {
 assert_true() {
     local condition="$1"
     local message="${2:-}"
-    
+
     ((TESTS_RUN++))
-    
+
     if eval "$condition"; then
         ((TESTS_PASSED++))
         if [[ "$VERBOSE" == true ]]; then
@@ -115,9 +115,9 @@ assert_true() {
 assert_false() {
     local condition="$1"
     local message="${2:-}"
-    
+
     ((TESTS_RUN++))
-    
+
     if ! eval "$condition"; then
         ((TESTS_PASSED++))
         if [[ "$VERBOSE" == true ]]; then
@@ -136,9 +136,9 @@ assert_false() {
 assert_file_exists() {
     local file="$1"
     local message="${2:-File should exist}"
-    
+
     ((TESTS_RUN++))
-    
+
     if [[ -f "$file" ]]; then
         ((TESTS_PASSED++))
         if [[ "$VERBOSE" == true ]]; then
@@ -156,9 +156,9 @@ assert_file_exists() {
 assert_command_exists() {
     local cmd="$1"
     local message="${2:-Command should exist}"
-    
+
     ((TESTS_RUN++))
-    
+
     if command -v "$cmd" &>/dev/null; then
         ((TESTS_PASSED++))
         if [[ "$VERBOSE" == true ]]; then
@@ -177,9 +177,9 @@ assert_exit_code() {
     local expected="$1"
     local actual="$2"
     local message="${3:-}"
-    
+
     ((TESTS_RUN++))
-    
+
     if [[ "$expected" == "$actual" ]]; then
         ((TESTS_PASSED++))
         if [[ "$VERBOSE" == true ]]; then
@@ -205,44 +205,44 @@ skip_test() {
 # Test utility functions
 test_utils() {
     print_test_header "Utility Functions Tests"
-    
+
     # Test trim function
     local trimmed
     trimmed=$(trim "  hello world  ")
     assert_equals "hello world" "$trimmed" "trim removes whitespace"
-    
+
     # Test to_lower function
     local lowered
     lowered=$(to_lower "HELLO")
     assert_equals "hello" "$lowered" "to_lower converts to lowercase"
-    
+
     # Test to_upper function
     local uppered
     uppered=$(to_upper "hello")
     assert_equals "HELLO" "$uppered" "to_upper converts to uppercase"
-    
+
     # Test contains function
     assert_true 'contains "hello world" "world"' "contains finds substring"
     assert_false 'contains "hello world" "foo"' "contains returns false for missing substring"
-    
+
     # Test starts_with function
     assert_true 'starts_with "hello world" "hello"' "starts_with finds prefix"
     assert_false 'starts_with "hello world" "world"' "starts_with returns false for wrong prefix"
-    
+
     # Test ends_with function
     assert_true 'ends_with "hello world" "world"' "ends_with finds suffix"
     assert_false 'ends_with "hello world" "hello"' "ends_with returns false for wrong suffix"
-    
+
     # Test timestamp function
     local ts
     ts=$(timestamp)
     assert_not_equals "" "$ts" "timestamp returns non-empty value"
-    
+
     # Test calc_percentage function
     local pct
     pct=$(calc_percentage 75 100)
     assert_equals "75" "$pct" "calc_percentage calculates correctly"
-    
+
     pct=$(calc_percentage 0 100)
     assert_equals "0" "$pct" "calc_percentage handles zero numerator"
 }
@@ -250,57 +250,63 @@ test_utils() {
 # Test config values
 test_config() {
     print_test_header "Configuration Tests"
-    
+
     # Test script version is set
     assert_not_equals "" "$SCRIPT_VERSION" "SCRIPT_VERSION is set"
-    
+
     # Test script name is set
     assert_equals "hardening-compliance-check" "$SCRIPT_NAME" "SCRIPT_NAME is correct"
-    
+
     # Test SSH config path
     assert_not_equals "" "$SSH_CONFIG" "SSH_CONFIG path is set"
-    
+
     # Test SSH benchmarks are populated
     assert_not_equals "" "${#SSH_BENCHMARKS[@]}" "SSH_BENCHMARKS has entries"
-    
+
     # Test kernel benchmarks are populated
     assert_not_equals "" "${#KERNEL_BENCHMARKS[@]}" "KERNEL_BENCHMARKS has entries"
-    
+
     # Test file permission benchmarks
     assert_not_equals "" "${#FILE_PERM_BENCHMARKS[@]}" "FILE_PERM_BENCHMARKS has entries"
-    
+
     # Test specific benchmark values
     assert_equals "no" "${SSH_BENCHMARKS[PermitRootLogin]}" "PermitRootLogin benchmark is 'no'"
     assert_equals "0" "${KERNEL_BENCHMARKS[net.ipv4.ip_forward]}" "ip_forward benchmark is '0'"
     assert_equals "600" "${FILE_PERM_BENCHMARKS[/etc/shadow]}" "/etc/shadow perms is '600'"
-    
+
     # Test severity levels
     assert_equals "critical" "${SSH_SEVERITY[PermitRootLogin]}" "PermitRootLogin severity is critical"
     assert_equals "critical" "${KERNEL_SEVERITY[kernel.randomize_va_space]}" "ASLR severity is critical"
+
+    # Test cache configuration
+    assert_not_equals "" "$CACHE_DIR" "CACHE_DIR is set"
+    assert_not_equals "" "$CACHE_FILE" "CACHE_FILE is set"
+    assert_not_equals "" "$CACHE_VERSION" "CACHE_VERSION is set"
+    assert_not_equals "" "$DEFAULT_CACHE_TTL" "DEFAULT_CACHE_TTL is set"
 }
 
 # Test helper functions
 test_helpers() {
     print_test_header "Helper Function Tests"
-    
+
     # Test command_exists
     assert_true 'command_exists bash' "command_exists finds bash"
     assert_false 'command_exists nonexistent_command_xyz' "command_exists returns false for missing command"
-    
+
     # Test file_exists with existing file
     assert_true 'file_exists /etc/passwd' "file_exists finds /etc/passwd"
     assert_false 'file_exists /nonexistent_file_xyz' "file_exists returns false for missing file"
-    
+
     # Test get_file_perms
     local perms
     perms=$(get_file_perms /etc/passwd)
     assert_not_equals "" "$perms" "get_file_perms returns value for /etc/passwd"
-    
+
     # Test get_distribution
     local dist
     dist=$(get_distribution)
     assert_not_equals "" "$dist" "get_distribution returns value"
-    
+
     # Test is_distribution
     # This will vary by system, just test it runs
     local result
@@ -311,23 +317,23 @@ test_helpers() {
 # Test main script exists and is executable
 test_script_structure() {
     print_test_header "Script Structure Tests"
-    
+
     # Test main script exists
     assert_file_exists "${PROJECT_DIR}/hardening-compliance-check.sh" "Main script exists"
-    
+
     # Test lib files exist
     assert_file_exists "${PROJECT_DIR}/lib/utils.sh" "utils.sh exists"
     assert_file_exists "${PROJECT_DIR}/lib/config.sh" "config.sh exists"
     assert_file_exists "${PROJECT_DIR}/lib/checks.sh" "checks.sh exists"
-    
+
     # Test scripts have shebang
     local shebang
     shebang=$(head -n1 "${PROJECT_DIR}/hardening-compliance-check.sh")
     assert_equals "#!/usr/bin/env bash" "$shebang" "Main script has correct shebang"
-    
+
     shebang=$(head -n1 "${PROJECT_DIR}/lib/utils.sh")
     assert_equals "#!/usr/bin/env bash" "$shebang" "utils.sh has correct shebang"
-    
+
     # Test scripts are syntactically valid
     local syntax_check
     if bash -n "${PROJECT_DIR}/hardening-compliance-check.sh" 2>/dev/null; then
@@ -341,7 +347,7 @@ test_script_structure() {
         ((TESTS_FAILED++))
         log_error "Main script has syntax errors"
     fi
-    
+
     if bash -n "${PROJECT_DIR}/lib/utils.sh" 2>/dev/null; then
         ((TESTS_RUN++))
         ((TESTS_PASSED++))
@@ -353,7 +359,7 @@ test_script_structure() {
         ((TESTS_FAILED++))
         log_error "utils.sh has syntax errors"
     fi
-    
+
     if bash -n "${PROJECT_DIR}/lib/config.sh" 2>/dev/null; then
         ((TESTS_RUN++))
         ((TESTS_PASSED++))
@@ -365,7 +371,7 @@ test_script_structure() {
         ((TESTS_FAILED++))
         log_error "config.sh has syntax errors"
     fi
-    
+
     if bash -n "${PROJECT_DIR}/lib/checks.sh" 2>/dev/null; then
         ((TESTS_RUN++))
         ((TESTS_PASSED++))
@@ -382,20 +388,21 @@ test_script_structure() {
 # Test help and version output
 test_cli_options() {
     print_test_header "CLI Options Tests"
-    
+
     # Test help output
     local help_output
     help_output=$("${PROJECT_DIR}/hardening-compliance-check.sh" --help 2>&1 || true)
     assert_not_equals "" "$help_output" "Help option produces output"
     assert_true '[[ "$help_output" == *"USAGE"* ]]' "Help output contains USAGE"
     assert_true '[[ "$help_output" == *"--help"* ]]' "Help output contains --help"
-    
+    assert_true '[[ "$help_output" == *"--cache"* ]]' "Help output contains --cache option"
+
     # Test version output
     local version_output
     version_output=$("${PROJECT_DIR}/hardening-compliance-check.sh" --version 2>&1 || true)
     assert_not_equals "" "$version_output" "Version option produces output"
     assert_true '[[ "$version_output" == *"version"* ]]' "Version output contains version"
-    
+
     # Test list-categories output
     local categories_output
     categories_output=$("${PROJECT_DIR}/hardening-compliance-check.sh" --list-categories 2>&1 || true)
@@ -403,7 +410,7 @@ test_cli_options() {
     assert_true '[[ "$categories_output" == *"ssh_hardening"* ]]' "Categories output contains ssh_hardening"
 }
 
-# Test benchmark counts
+# Test benchmark coverage
 test_benchmark_coverage() {
     print_test_header "Benchmark Coverage Tests"
 
@@ -525,10 +532,10 @@ test_input_validation() {
     local sanitized
     sanitized=$(sanitize_config_value "hello world")
     assert_equals "hello world" "$sanitized" "sanitize_config_value keeps clean input"
-    
+
     sanitized=$(sanitize_config_value 'test;rm -rf /')
     assert_false '[[ "$sanitized" == *";"* ]]' "sanitize_config_value removes semicolons"
-    
+
     sanitized=$(sanitize_config_value 'test$(whoami)')
     assert_false '[[ "$sanitized" == *"$"* ]]' "sanitize_config_value removes dollar signs"
 
@@ -556,6 +563,87 @@ test_input_validation() {
     assert_false 'validate_output_format "html"' "validate_output_format rejects html"
 }
 
+# Test cache functions
+test_cache_functions() {
+    print_test_header "Cache Function Tests"
+
+    # Test init_cache creates directory
+    init_cache
+    assert_true '[[ -d "$CACHE_DIR" ]]' "init_cache creates cache directory"
+
+    # Test get_cache_path
+    local cache_path
+    cache_path=$(get_cache_path)
+    assert_equals "$CACHE_FILE" "$cache_path" "get_cache_path returns correct path"
+
+    # Test clear_cache when no cache exists
+    rm -f "$CACHE_FILE" 2>/dev/null || true
+    clear_cache
+    assert_true '[[ $? -eq 0 ]]' "clear_cache succeeds when no cache exists"
+
+    # Test write_cache_header
+    write_cache_header
+    assert_true '[[ -f "$CACHE_FILE" ]]' "write_cache_header creates cache file"
+
+    # Test cache header format
+    local header
+    header=$(head -1 "$CACHE_FILE")
+    assert_true '[[ "$header" == "#CACHE_META:"* ]]' "cache header has correct format"
+
+    # Test cache version in header
+    local version
+    version=$(get_cache_version)
+    assert_equals "$CACHE_VERSION" "$version" "cache version matches"
+
+    # Test store and retrieve cache result
+    store_cache_result "test_check" "pass" "test details"
+    local cached_result
+    cached_result=$(get_cached_result "test_check")
+    assert_equals "pass" "$cached_result" "get_cached_result returns stored value"
+
+    local cached_details
+    cached_details=$(get_cached_details "test_check")
+    assert_equals "test details" "$cached_details" "get_cached_details returns stored value"
+
+    # Test is_cache_empty
+    assert_false 'is_cache_empty' "is_cache_empty returns false after storing"
+
+    # Test cache age
+    local age
+    age=$(get_cache_age)
+    assert_not_equals "" "$age" "get_cache_age returns value"
+
+    # Test cache TTL validation (cache should be valid with default TTL)
+    assert_true 'is_cache_valid 3600' "is_cache_valid returns true for fresh cache"
+
+    # Test is_cache_valid with zero TTL (should always be invalid)
+    assert_false 'is_cache_valid 0' "is_cache_valid returns false for zero TTL"
+
+    # Clean up test cache
+    rm -f "$CACHE_FILE" 2>/dev/null || true
+}
+
+# Test cache CLI options
+test_cache_cli() {
+    print_test_header "Cache CLI Tests"
+
+    # Test --clear-cache option
+    local clear_output
+    clear_output=$("${PROJECT_DIR}/hardening-compliance-check.sh" --clear-cache 2>&1 || true)
+    assert_not_equals "" "$clear_output" "--clear-cache produces output"
+    assert_true '[[ "$clear_output" == *"Cache"* || "$clear_output" == *"cache"* ]]' "clear-cache output mentions cache"
+
+    # Test --cache-ttl with valid value
+    local ttl_output
+    ttl_output=$("${PROJECT_DIR}/hardening-compliance-check.sh" --cache-ttl 300 --help 2>&1 || true)
+    assert_exit_code 0 "$?" "--cache-ttl with valid value succeeds"
+
+    # Test --cache-ttl with invalid value
+    local invalid_ttl_output
+    invalid_ttl_output=$("${PROJECT_DIR}/hardening-compliance-check.sh" --cache-ttl abc 2>&1 || true)
+    assert_true '[[ "$invalid_ttl_output" == *"error"* || "$invalid_ttl_output" == *"Error"* || "$invalid_ttl_output" == *"must be"* ]]' "--cache-ttl with invalid value shows error"
+}
+
 # Print test summary
 print_summary() {
     echo ""
@@ -574,14 +662,14 @@ print_summary() {
     print_color "$COLOR_RED" "  Failed:             $TESTS_FAILED"
     print_color "$COLOR_YELLOW" "  Skipped:            $TESTS_SKIPPED"
     echo ""
-    
+
     local pass_rate=0
     if [[ $TESTS_RUN -gt 0 ]]; then
         pass_rate=$(( (TESTS_PASSED * 100) / TESTS_RUN ))
     fi
     echo "  Pass rate:          ${pass_rate}%"
     echo ""
-    
+
     if [[ $TESTS_FAILED -eq 0 ]]; then
         print_color "$COLOR_GREEN" "  All tests passed!"
         return 0
@@ -618,7 +706,7 @@ parse_test_args() {
 # Main test runner
 main() {
     parse_test_args "$@"
-    
+
     echo ""
     if supports_color; then
         echo -e "${COLOR_BOLD}${COLOR_GREEN}========================================${COLOR_RESET}"
@@ -638,6 +726,8 @@ main() {
     test_cli_options
     test_benchmark_coverage
     test_input_validation
+    test_cache_functions
+    test_cache_cli
 
     # Print summary
     print_summary


### PR DESCRIPTION
Implemented caching to speed up repeated compliance checks by storing results between runs. Added `--cache`, `--no-cache`, `--clear-cache`, and `--cache-ttl` options to control caching behavior. The cache reduces redundant system calls when re-running checks against the same configuration. closes #4