### PR TITLE
handle missing files more gracefully

### DIFF
--- a/hardening-compliance-check.sh
+++ b/hardening-compliance-check.sh
@@ -28,6 +28,30 @@ set -euo pipefail
 # Script directory for sourcing modules
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Verify required library files exist before sourcing
+REQUIRED_LIB_FILES=(
+    "lib/utils.sh"
+    "lib/config.sh"
+    "lib/checks.sh"
+)
+
+for lib_file in "${REQUIRED_LIB_FILES[@]}"; do
+    lib_path="${SCRIPT_DIR}/${lib_file}"
+    if [[ ! -f "$lib_path" ]]; then
+        echo "[FAIL] Required library file not found: ${lib_file}" >&2
+        echo "       Expected at: ${lib_path}" >&2
+        echo "" >&2
+        echo "The hardening-compliance-check script requires all library files" >&2
+        echo "in the lib/ directory. Please ensure the installation is complete." >&2
+        exit 1
+    fi
+    if [[ ! -r "$lib_path" ]]; then
+        echo "[FAIL] Required library file not readable: ${lib_file}" >&2
+        echo "       Expected at: ${lib_path}" >&2
+        exit 1
+    fi
+done
+
 # Source library modules
 source "${SCRIPT_DIR}/lib/utils.sh"
 source "${SCRIPT_DIR}/lib/config.sh"
@@ -421,7 +445,7 @@ main() {
     fi
 
     # Run checks
-    local exit_code
+    local exit_code=0
 
     if [[ -n "$SELECTED_CATEGORY" ]]; then
         print_header "LINUX HARDENING COMPLIANCE CHECK"
@@ -429,11 +453,9 @@ main() {
         echo "  Started: $(timestamp)"
         echo ""
 
-        run_category_checks "$SELECTED_CATEGORY"
-        exit_code=$?
+        run_category_checks "$SELECTED_CATEGORY" || exit_code=$?
     else
-        run_all_checks
-        exit_code=$?
+        run_all_checks || exit_code=$?
     fi
 
     # Calculate duration
@@ -443,18 +465,39 @@ main() {
 
     # Generate output file if specified
     if [[ -n "$OUTPUT_FILE" ]]; then
-        case "$OUTPUT_FORMAT" in
-            json)
-                generate_json_output 0 0 0 0 > "$OUTPUT_FILE"
-                ;;
-            csv)
-                generate_csv_output 0 0 0 > "$OUTPUT_FILE"
-                ;;
-            *)
-                # Text output already printed to stdout
-                log_info "Results written to: $OUTPUT_FILE"
-                ;;
-        esac
+        # Ensure parent directory exists
+        local output_dir
+        output_dir="$(dirname "$OUTPUT_FILE")"
+        if [[ ! -d "$output_dir" ]]; then
+            log_error "Output directory does not exist: $output_dir"
+            exit_code=$EXIT_FAILURE
+        elif [[ ! -w "$output_dir" ]]; then
+            log_error "Output directory is not writable: $output_dir"
+            exit_code=$EXIT_FAILURE
+        else
+            case "$OUTPUT_FORMAT" in
+                json)
+                    if generate_json_output 0 0 0 0 > "$OUTPUT_FILE" 2>/dev/null; then
+                        log_info "Results written to: $OUTPUT_FILE"
+                    else
+                        log_error "Failed to write output file: $OUTPUT_FILE"
+                        exit_code=$EXIT_FAILURE
+                    fi
+                    ;;
+                csv)
+                    if generate_csv_output 0 0 0 > "$OUTPUT_FILE" 2>/dev/null; then
+                        log_info "Results written to: $OUTPUT_FILE"
+                    else
+                        log_error "Failed to write output file: $OUTPUT_FILE"
+                        exit_code=$EXIT_FAILURE
+                    fi
+                    ;;
+                *)
+                    # Text output already printed to stdout
+                    log_info "Results written to: $OUTPUT_FILE"
+                    ;;
+            esac
+        fi
     fi
 
     # Print completion message

--- a/lib/checks.sh
+++ b/lib/checks.sh
@@ -72,22 +72,22 @@ check_ssh_config() {
             # Key not present - check if it's a critical setting
             if [[ "$severity" == "$SEVERITY_CRITICAL" || "$severity" == "$SEVERITY_HIGH" ]]; then
                 print_check_result "SSH $key" "fail" "Not configured (expected: $expected)"
-                ((fail_count++))
+                ((fail_count++)) || true
             else
                 print_check_result "SSH $key" "warn" "Not configured"
-                ((skip_count++))
+                ((skip_count++)) || true
             fi
         elif ! validate_config_value "$key" "$current" "$param_type"; then
             # Invalid value format
             print_check_result "SSH $key" "fail" "Invalid format: '$current'"
-            ((fail_count++))
-            ((invalid_count++))
+            ((fail_count++)) || true
+            ((invalid_count++)) || true
         elif [[ "$current" == "$expected" ]]; then
             print_check_result "SSH $key" "pass"
-            ((pass_count++))
+            ((pass_count++)) || true
         else
             print_check_result "SSH $key" "fail" "Current: $current (expected: $expected)"
-            ((fail_count++))
+            ((fail_count++)) || true
         fi
     done
 
@@ -125,6 +125,13 @@ check_kernel_params() {
     print_subheader "Kernel Parameter Checks"
     echo ""
 
+    if [[ ! -f "$SYSCTL_CONFIG" && ! -d /proc/sys ]]; then
+        log_warning "No sysctl configuration found — kernel parameter checks skipped"
+        echo ""
+        store_cache_result "kernel_params" "skip" "No sysctl config found"
+        return $EXIT_SKIP
+    fi
+
     for param in "${!KERNEL_BENCHMARKS[@]}"; do
         local expected="${KERNEL_BENCHMARKS[$param]}"
         local severity="${KERNEL_SEVERITY[$param]}"
@@ -139,22 +146,22 @@ check_kernel_params() {
             # Parameter not available - might be kernel/distro specific
             if [[ "$severity" == "$SEVERITY_CRITICAL" ]]; then
                 print_check_result "Kernel $param" "fail" "Not set (expected: $expected)"
-                ((fail_count++))
+                ((fail_count++)) || true
             else
                 print_check_result "Kernel $param" "skip" "Parameter not available"
-                ((skip_count++))
+                ((skip_count++)) || true
             fi
         elif ! validate_kernel_numeric "$current"; then
             # Invalid value format for kernel parameter
             print_check_result "Kernel $param" "fail" "Invalid format: '$current'"
-            ((fail_count++))
-            ((invalid_count++))
+            ((fail_count++)) || true
+            ((invalid_count++)) || true
         elif [[ "$current" == "$expected" ]]; then
             print_check_result "Kernel $param" "pass"
-            ((pass_count++))
+            ((pass_count++)) || true
         else
             print_check_result "Kernel $param" "fail" "Current: $current (expected: $expected)"
-            ((fail_count++))
+            ((fail_count++)) || true
         fi
     done
 
@@ -199,15 +206,15 @@ check_file_permissions() {
 
         if [[ ! -e "$file" ]]; then
             print_check_result "File $file" "skip" "File does not exist"
-            ((skip_count++))
+            ((skip_count++)) || true
             continue
         fi
 
         # Validate file path before reading
         if ! validate_file_path "$file"; then
             print_check_result "File $file" "fail" "Invalid path format"
-            ((fail_count++))
-            ((invalid_count++))
+            ((fail_count++)) || true
+            ((invalid_count++)) || true
             continue
         fi
 
@@ -215,18 +222,18 @@ check_file_permissions() {
 
         if [[ -z "$current" ]]; then
             print_check_result "File $file" "skip" "Cannot read permissions"
-            ((skip_count++))
+            ((skip_count++)) || true
         elif ! validate_file_permission "$current"; then
             # Invalid permission format
             print_check_result "File $file" "fail" "Invalid format: '$current'"
-            ((fail_count++))
-            ((invalid_count++))
+            ((fail_count++)) || true
+            ((invalid_count++)) || true
         elif [[ "$current" == "$expected" ]]; then
             print_check_result "File $file" "pass"
-            ((pass_count++))
+            ((pass_count++)) || true
         else
             print_check_result "File $file" "fail" "Current: $current (expected: $expected)"
-            ((fail_count++))
+            ((fail_count++)) || true
         fi
     done
 
@@ -259,19 +266,31 @@ check_empty_passwords() {
     print_subheader "Empty Password Check"
     echo ""
 
+    if [[ ! -f /etc/shadow ]]; then
+        log_warning "/etc/shadow not found — skipping empty password check"
+        echo ""
+        store_cache_result "empty_passwords" "skip" "/etc/shadow not found"
+        return $EXIT_SKIP
+    fi
+
+    if [[ ! -r /etc/shadow ]]; then
+        log_warning "/etc/shadow not readable — skipping empty password check (run as root)"
+        echo ""
+        store_cache_result "empty_passwords" "skip" "/etc/shadow not readable"
+        return $EXIT_SKIP
+    fi
+
     local empty_pass_users=0
 
-    if [[ -f /etc/shadow ]]; then
-        while IFS=: read -r username password rest; do
-            if [[ "$password" == "" || "$password" == "!" || "$password" == "*" ]]; then
-                continue
-            fi
-            if [[ "$password" =~ ^!?$ ]]; then
-                ((empty_pass_users++))
-                log_warning "User '$username' has empty or disabled password"
-            fi
-        done < /etc/shadow
-    fi
+    while IFS=: read -r username password rest; do
+        if [[ "$password" == "" || "$password" == "!" || "$password" == "*" ]]; then
+            continue
+        fi
+        if [[ "$password" =~ ^!?$ ]]; then
+            ((empty_pass_users++)) || true
+            log_warning "User '$username' has empty or disabled password"
+        fi
+    done < /etc/shadow
 
     if [[ $empty_pass_users -eq 0 ]]; then
         print_check_result "No empty passwords" "pass"
@@ -290,6 +309,20 @@ check_empty_passwords() {
 check_uid_zero_users() {
     print_subheader "UID 0 User Check"
     echo ""
+
+    if [[ ! -f /etc/passwd ]]; then
+        log_warning "/etc/passwd not found — skipping UID 0 user check"
+        echo ""
+        store_cache_result "uid_zero_users" "skip" "/etc/passwd not found"
+        return $EXIT_SKIP
+    fi
+
+    if [[ ! -r /etc/passwd ]]; then
+        log_warning "/etc/passwd not readable — skipping UID 0 user check"
+        echo ""
+        store_cache_result "uid_zero_users" "skip" "/etc/passwd not readable"
+        return $EXIT_SKIP
+    fi
 
     local uid_zero_users=()
 
@@ -338,28 +371,28 @@ check_password_policy() {
 
         if [[ -z "$current" ]]; then
             print_check_result "Password $key" "warn" "Not configured (recommended: $expected)"
-            ((pass_count++))
+            ((pass_count++)) || true
         elif ! validate_password_numeric "$current"; then
             # Invalid value format
             print_check_result "Password $key" "fail" "Invalid format: '$current'"
-            ((fail_count++))
-            ((invalid_count++))
+            ((fail_count++)) || true
+            ((invalid_count++)) || true
         elif [[ "$key" == "PASS_MAX_DAYS" || "$key" == "PASS_MIN_DAYS" || "$key" == "LOGIN_RETRIES" ]]; then
             # For these, lower or equal is better
             if [[ "$current" -le "$expected" ]]; then
                 print_check_result "Password $key" "pass" "Current: $current"
-                ((pass_count++))
+                ((pass_count++)) || true
             else
                 print_check_result "Password $key" "fail" "Current: $current (max recommended: $expected)"
-                ((fail_count++))
+                ((fail_count++)) || true
             fi
         else
             if [[ "$current" == "$expected" ]]; then
                 print_check_result "Password $key" "pass"
-                ((pass_count++))
+                ((pass_count++)) || true
             else
                 print_check_result "Password $key" "fail" "Current: $current (expected: $expected)"
-                ((fail_count++))
+                ((fail_count++)) || true
             fi
         fi
     done
@@ -396,10 +429,10 @@ check_dangerous_services() {
     for service in "${DISABLED_SERVICES[@]}"; do
         if service_enabled "$service" || service_active "$service"; then
             print_check_result "Service $service disabled" "fail" "Service is active/enabled"
-            ((fail_count++))
+            ((fail_count++)) || true
         else
             print_check_result "Service $service disabled" "pass"
-            ((pass_count++))
+            ((pass_count++)) || true
         fi
     done
 
@@ -431,10 +464,10 @@ check_required_services() {
         if command_exists systemctl; then
             if service_enabled "$service" || service_active "$service"; then
                 print_check_result "Service $service enabled" "pass"
-                ((pass_count++))
+                ((pass_count++)) || true
             else
                 print_check_result "Service $service enabled" "warn" "Service not active"
-                ((fail_count++))
+                ((fail_count++)) || true
             fi
         else
             print_check_result "Service $service" "skip" "systemctl not available"
@@ -465,25 +498,25 @@ check_cron_at_restrictions() {
     # Check cron.allow exists or cron.deny doesn't exist
     if [[ -f "$CRON_ALLOW" ]]; then
         print_check_result "Cron access restricted" "pass" "cron.allow exists"
-        ((pass_count++))
+        ((pass_count++)) || true
     elif [[ -f "$CRON_DENY" ]]; then
         print_check_result "Cron access restricted" "warn" "Using cron.deny instead of cron.allow"
-        ((fail_count++))
+        ((fail_count++)) || true
     else
         print_check_result "Cron access restricted" "fail" "No cron.allow file"
-        ((fail_count++))
+        ((fail_count++)) || true
     fi
 
     # Check at.allow exists or at.deny doesn't exist
     if [[ -f "$AT_ALLOW" ]]; then
         print_check_result "At access restricted" "pass" "at.allow exists"
-        ((pass_count++))
+        ((pass_count++)) || true
     elif [[ -f "$AT_DENY" ]]; then
         print_check_result "At access restricted" "warn" "Using at.deny instead of at.allow"
-        ((fail_count++))
+        ((fail_count++)) || true
     else
         print_check_result "At access restricted" "fail" "No at.allow file"
-        ((fail_count++))
+        ((fail_count++)) || true
     fi
 
     echo ""
@@ -523,10 +556,10 @@ check_world_writable() {
 
     if [[ ${#world_writable_files[@]} -eq 0 ]]; then
         print_check_result "No world-writable system files" "pass"
-        ((pass_count++))
+        ((pass_count++)) || true
     else
         print_check_result "World-writable files found" "fail" "Count: ${#world_writable_files[@]}"
-        ((fail_count++))
+        ((fail_count++)) || true
         for file in "${world_writable_files[@]:0:5}"; do
             echo "    - $file"
         done
@@ -572,10 +605,10 @@ check_unowned_files() {
 
     if [[ ${#unowned_files[@]} -eq 0 ]]; then
         print_check_result "No unowned system files" "pass"
-        ((pass_count++))
+        ((pass_count++)) || true
     else
         print_check_result "Unowned files found" "fail" "Count: ${#unowned_files[@]}"
-        ((fail_count++))
+        ((fail_count++)) || true
         for file in "${unowned_files[@]:0:5}"; do
             echo "    - $file"
         done
@@ -649,10 +682,10 @@ check_suid_sgid() {
 
     if [[ ${#suid_files[@]} -eq 0 ]]; then
         print_check_result "No SUID/SGID in non-standard dirs" "pass"
-        ((pass_count++))
+        ((pass_count++)) || true
     else
         print_check_result "SUID/SGID in non-standard locations" "warn" "Count: ${#suid_files[@]}"
-        ((fail_count++))
+        ((fail_count++)) || true
         for file in "${suid_files[@]:0:5}"; do
             echo "    - $file"
         done
@@ -699,9 +732,9 @@ run_all_checks() {
     check_file_permissions
     result=$?
     case $result in
-        0) ((total_pass++)) ;;
-        1) ((total_fail++)) ;;
-        *) ((total_skip++)) ;;
+        0) ((total_pass++)) || true ;;
+        1) ((total_fail++)) || true ;;
+        *) ((total_skip++)) || true ;;
     esac
 
     # User accounts
@@ -709,25 +742,25 @@ run_all_checks() {
     check_empty_passwords
     result=$?
     case $result in
-        0) ((total_pass++)) ;;
-        1) ((total_fail++)) ;;
-        *) ((total_skip++)) ;;
+        0) ((total_pass++)) || true ;;
+        1) ((total_fail++)) || true ;;
+        *) ((total_skip++)) || true ;;
     esac
 
     check_uid_zero_users
     result=$?
     case $result in
-        0) ((total_pass++)) ;;
-        1) ((total_fail++)) ;;
-        *) ((total_skip++)) ;;
+        0) ((total_pass++)) || true ;;
+        1) ((total_fail++)) || true ;;
+        *) ((total_skip++)) || true ;;
     esac
 
     check_password_policy
     result=$?
     case $result in
-        0) ((total_pass++)) ;;
-        1) ((total_fail++)) ;;
-        *) ((total_skip++)) ;;
+        0) ((total_pass++)) || true ;;
+        1) ((total_fail++)) || true ;;
+        *) ((total_skip++)) || true ;;
     esac
 
     # SSH hardening
@@ -735,9 +768,9 @@ run_all_checks() {
     check_ssh_config
     result=$?
     case $result in
-        0) ((total_pass++)) ;;
-        1) ((total_fail++)) ;;
-        *) ((total_skip++)) ;;
+        0) ((total_pass++)) || true ;;
+        1) ((total_fail++)) || true ;;
+        *) ((total_skip++)) || true ;;
     esac
 
     # Kernel hardening
@@ -745,9 +778,9 @@ run_all_checks() {
     check_kernel_params
     result=$?
     case $result in
-        0) ((total_pass++)) ;;
-        1) ((total_fail++)) ;;
-        *) ((total_skip++)) ;;
+        0) ((total_pass++)) || true ;;
+        1) ((total_fail++)) || true ;;
+        *) ((total_skip++)) || true ;;
     esac
 
     # Service hardening
@@ -755,25 +788,25 @@ run_all_checks() {
     check_dangerous_services
     result=$?
     case $result in
-        0) ((total_pass++)) ;;
-        1) ((total_fail++)) ;;
-        *) ((total_skip++)) ;;
+        0) ((total_pass++)) || true ;;
+        1) ((total_fail++)) || true ;;
+        *) ((total_skip++)) || true ;;
     esac
 
     check_required_services
     result=$?
     case $result in
-        0) ((total_pass++)) ;;
-        1) ((total_fail++)) ;;
-        *) ((total_skip++)) ;;
+        0) ((total_pass++)) || true ;;
+        1) ((total_fail++)) || true ;;
+        *) ((total_skip++)) || true ;;
     esac
 
     check_cron_at_restrictions
     result=$?
     case $result in
-        0) ((total_pass++)) ;;
-        1) ((total_fail++)) ;;
-        *) ((total_skip++)) ;;
+        0) ((total_pass++)) || true ;;
+        1) ((total_fail++)) || true ;;
+        *) ((total_skip++)) || true ;;
     esac
 
     # Additional security checks
@@ -781,33 +814,33 @@ run_all_checks() {
     check_world_writable
     result=$?
     case $result in
-        0) ((total_pass++)) ;;
-        1) ((total_fail++)) ;;
-        *) ((total_skip++)) ;;
+        0) ((total_pass++)) || true ;;
+        1) ((total_fail++)) || true ;;
+        *) ((total_skip++)) || true ;;
     esac
 
     check_unowned_files
     result=$?
     case $result in
-        0) ((total_pass++)) ;;
-        1) ((total_fail++)) ;;
-        *) ((total_skip++)) ;;
+        0) ((total_pass++)) || true ;;
+        1) ((total_fail++)) || true ;;
+        *) ((total_skip++)) || true ;;
     esac
 
     check_suid_sgid
     result=$?
     case $result in
-        0) ((total_pass++)) ;;
-        1) ((total_fail++)) ;;
-        *) ((total_skip++)) ;;
+        0) ((total_pass++)) || true ;;
+        1) ((total_fail++)) || true ;;
+        *) ((total_skip++)) || true ;;
     esac
 
     check_audit_status
     result=$?
     case $result in
-        0) ((total_pass++)) ;;
-        1) ((total_fail++)) ;;
-        *) ((total_skip++)) ;;
+        0) ((total_pass++)) || true ;;
+        1) ((total_fail++)) || true ;;
+        *) ((total_skip++)) || true ;;
     esac
 
     # Summary

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -568,8 +568,8 @@ init_cache() {
 # Check if cache is enabled and valid
 # Returns 0 if cache should be used, 1 otherwise
 is_cache_valid() {
-    # Check if caching is enabled
-    if [[ "$USE_CACHE" != "true" ]]; then
+    # Check if caching is enabled (default to false if not set)
+    if [[ "${USE_CACHE:-false}" != "true" ]]; then
         return 1
     fi
 
@@ -592,7 +592,7 @@ is_cache_valid() {
     fi
 
     local age=$((current_time - cache_age))
-    if [[ $age -lt $CACHE_TTL ]]; then
+    if [[ $age -lt ${CACHE_TTL:-3600} ]]; then
         return 0
     fi
 
@@ -683,8 +683,8 @@ store_cache_result() {
     local status="$2"
     local details="${3:-}"
 
-    # Check if caching is enabled
-    if [[ "$USE_CACHE" != "true" ]]; then
+    # Check if caching is enabled (default to false if not set)
+    if [[ "${USE_CACHE:-false}" != "true" ]]; then
         return 1
     fi
 
@@ -709,8 +709,8 @@ write_cache_header() {
     local current_time
     current_time=$(timestamp_epoch)
 
-    # Check if caching is enabled
-    if [[ "$USE_CACHE" != "true" ]]; then
+    # Check if caching is enabled (default to false if not set)
+    if [[ "${USE_CACHE:-false}" != "true" ]]; then
         return 1
     fi
 

--- a/tests/test_runner.sh
+++ b/tests/test_runner.sh
@@ -50,16 +50,16 @@ assert_equals() {
     local actual="$2"
     local message="${3:-}"
 
-    ((TESTS_RUN++))
+    ((TESTS_RUN++)) || true
 
     if [[ "$expected" == "$actual" ]]; then
-        ((TESTS_PASSED++))
+        ((TESTS_PASSED++)) || true
         if [[ "$VERBOSE" == true ]]; then
             log_success "assert_equals: $message"
         fi
         return 0
     else
-        ((TESTS_FAILED++))
+        ((TESTS_FAILED++)) || true
         log_error "assert_equals: $message"
         echo "  Expected: '$expected'"
         echo "  Actual:   '$actual'"
@@ -73,16 +73,16 @@ assert_not_equals() {
     local actual="$2"
     local message="${3:-}"
 
-    ((TESTS_RUN++))
+    ((TESTS_RUN++)) || true
 
     if [[ "$expected" != "$actual" ]]; then
-        ((TESTS_PASSED++))
+        ((TESTS_PASSED++)) || true
         if [[ "$VERBOSE" == true ]]; then
             log_success "assert_not_equals: $message"
         fi
         return 0
     else
-        ((TESTS_FAILED++))
+        ((TESTS_FAILED++)) || true
         log_error "assert_not_equals: $message"
         echo "  Expected not: '$expected'"
         echo "  Actual:       '$actual'"
@@ -95,16 +95,16 @@ assert_true() {
     local condition="$1"
     local message="${2:-}"
 
-    ((TESTS_RUN++))
+    ((TESTS_RUN++)) || true
 
     if eval "$condition"; then
-        ((TESTS_PASSED++))
+        ((TESTS_PASSED++)) || true
         if [[ "$VERBOSE" == true ]]; then
             log_success "assert_true: $message"
         fi
         return 0
     else
-        ((TESTS_FAILED++))
+        ((TESTS_FAILED++)) || true
         log_error "assert_true: $message"
         echo "  Condition: $condition"
         return 1
@@ -116,16 +116,16 @@ assert_false() {
     local condition="$1"
     local message="${2:-}"
 
-    ((TESTS_RUN++))
+    ((TESTS_RUN++)) || true
 
     if ! eval "$condition"; then
-        ((TESTS_PASSED++))
+        ((TESTS_PASSED++)) || true
         if [[ "$VERBOSE" == true ]]; then
             log_success "assert_false: $message"
         fi
         return 0
     else
-        ((TESTS_FAILED++))
+        ((TESTS_FAILED++)) || true
         log_error "assert_false: $message"
         echo "  Condition: $condition"
         return 1
@@ -137,16 +137,16 @@ assert_file_exists() {
     local file="$1"
     local message="${2:-File should exist}"
 
-    ((TESTS_RUN++))
+    ((TESTS_RUN++)) || true
 
     if [[ -f "$file" ]]; then
-        ((TESTS_PASSED++))
+        ((TESTS_PASSED++)) || true
         if [[ "$VERBOSE" == true ]]; then
             log_success "$message: $file"
         fi
         return 0
     else
-        ((TESTS_FAILED++))
+        ((TESTS_FAILED++)) || true
         log_error "$message: $file"
         return 1
     fi
@@ -157,16 +157,16 @@ assert_command_exists() {
     local cmd="$1"
     local message="${2:-Command should exist}"
 
-    ((TESTS_RUN++))
+    ((TESTS_RUN++)) || true
 
     if command -v "$cmd" &>/dev/null; then
-        ((TESTS_PASSED++))
+        ((TESTS_PASSED++)) || true
         if [[ "$VERBOSE" == true ]]; then
             log_success "$message: $cmd"
         fi
         return 0
     else
-        ((TESTS_FAILED++))
+        ((TESTS_FAILED++)) || true
         log_error "$message: $cmd"
         return 1
     fi
@@ -178,16 +178,16 @@ assert_exit_code() {
     local actual="$2"
     local message="${3:-}"
 
-    ((TESTS_RUN++))
+    ((TESTS_RUN++)) || true
 
     if [[ "$expected" == "$actual" ]]; then
-        ((TESTS_PASSED++))
+        ((TESTS_PASSED++)) || true
         if [[ "$VERBOSE" == true ]]; then
             log_success "assert_exit_code: $message"
         fi
         return 0
     else
-        ((TESTS_FAILED++))
+        ((TESTS_FAILED++)) || true
         log_error "assert_exit_code: $message"
         echo "  Expected: $expected"
         echo "  Actual:   $actual"
@@ -198,7 +198,7 @@ assert_exit_code() {
 # Skip a test
 skip_test() {
     local message="$1"
-    ((TESTS_SKIPPED++))
+    ((TESTS_SKIPPED++)) || true
     log_warning "SKIPPED: $message"
 }
 
@@ -337,50 +337,50 @@ test_script_structure() {
     # Test scripts are syntactically valid
     local syntax_check
     if bash -n "${PROJECT_DIR}/hardening-compliance-check.sh" 2>/dev/null; then
-        ((TESTS_RUN++))
-        ((TESTS_PASSED++))
+        ((TESTS_RUN++)) || true
+        ((TESTS_PASSED++)) || true
         if [[ "$VERBOSE" == true ]]; then
             log_success "Main script syntax is valid"
         fi
     else
-        ((TESTS_RUN++))
-        ((TESTS_FAILED++))
+        ((TESTS_RUN++)) || true
+        ((TESTS_FAILED++)) || true
         log_error "Main script has syntax errors"
     fi
 
     if bash -n "${PROJECT_DIR}/lib/utils.sh" 2>/dev/null; then
-        ((TESTS_RUN++))
-        ((TESTS_PASSED++))
+        ((TESTS_RUN++)) || true
+        ((TESTS_PASSED++)) || true
         if [[ "$VERBOSE" == true ]]; then
             log_success "utils.sh syntax is valid"
         fi
     else
-        ((TESTS_RUN++))
-        ((TESTS_FAILED++))
+        ((TESTS_RUN++)) || true
+        ((TESTS_FAILED++)) || true
         log_error "utils.sh has syntax errors"
     fi
 
     if bash -n "${PROJECT_DIR}/lib/config.sh" 2>/dev/null; then
-        ((TESTS_RUN++))
-        ((TESTS_PASSED++))
+        ((TESTS_RUN++)) || true
+        ((TESTS_PASSED++)) || true
         if [[ "$VERBOSE" == true ]]; then
             log_success "config.sh syntax is valid"
         fi
     else
-        ((TESTS_RUN++))
-        ((TESTS_FAILED++))
+        ((TESTS_RUN++)) || true
+        ((TESTS_FAILED++)) || true
         log_error "config.sh has syntax errors"
     fi
 
     if bash -n "${PROJECT_DIR}/lib/checks.sh" 2>/dev/null; then
-        ((TESTS_RUN++))
-        ((TESTS_PASSED++))
+        ((TESTS_RUN++)) || true
+        ((TESTS_PASSED++)) || true
         if [[ "$VERBOSE" == true ]]; then
             log_success "checks.sh syntax is valid"
         fi
     else
-        ((TESTS_RUN++))
-        ((TESTS_FAILED++))
+        ((TESTS_RUN++)) || true
+        ((TESTS_FAILED++)) || true
         log_error "checks.sh has syntax errors"
     fi
 }
@@ -417,56 +417,56 @@ test_benchmark_coverage() {
     # Test SSH benchmarks count (should have at least 10)
     local ssh_count=${#SSH_BENCHMARKS[@]}
     if [[ $ssh_count -ge 10 ]]; then
-        ((TESTS_RUN++))
-        ((TESTS_PASSED++))
+        ((TESTS_RUN++)) || true
+        ((TESTS_PASSED++)) || true
         if [[ "$VERBOSE" == true ]]; then
             log_success "SSH benchmarks count: $ssh_count (>= 10)"
         fi
     else
-        ((TESTS_RUN++))
-        ((TESTS_FAILED++))
+        ((TESTS_RUN++)) || true
+        ((TESTS_FAILED++)) || true
         log_error "SSH benchmarks count: $ssh_count (< 10)"
     fi
 
     # Test kernel benchmarks count (should have at least 15)
     local kernel_count=${#KERNEL_BENCHMARKS[@]}
     if [[ $kernel_count -ge 15 ]]; then
-        ((TESTS_RUN++))
-        ((TESTS_PASSED++))
+        ((TESTS_RUN++)) || true
+        ((TESTS_PASSED++)) || true
         if [[ "$VERBOSE" == true ]]; then
             log_success "Kernel benchmarks count: $kernel_count (>= 15)"
         fi
     else
-        ((TESTS_RUN++))
-        ((TESTS_FAILED++))
+        ((TESTS_RUN++)) || true
+        ((TESTS_FAILED++)) || true
         log_error "Kernel benchmarks count: $kernel_count (< 15)"
     fi
 
     # Test file permission benchmarks count (should have at least 10)
     local file_count=${#FILE_PERM_BENCHMARKS[@]}
     if [[ $file_count -ge 10 ]]; then
-        ((TESTS_RUN++))
-        ((TESTS_PASSED++))
+        ((TESTS_RUN++)) || true
+        ((TESTS_PASSED++)) || true
         if [[ "$VERBOSE" == true ]]; then
             log_success "File permission benchmarks count: $file_count (>= 10)"
         fi
     else
-        ((TESTS_RUN++))
-        ((TESTS_FAILED++))
+        ((TESTS_RUN++)) || true
+        ((TESTS_FAILED++)) || true
         log_error "File permission benchmarks count: $file_count (< 10)"
     fi
 
     # Test disabled services count (should have at least 5)
     local service_count=${#DISABLED_SERVICES[@]}
     if [[ $service_count -ge 5 ]]; then
-        ((TESTS_RUN++))
-        ((TESTS_PASSED++))
+        ((TESTS_RUN++)) || true
+        ((TESTS_PASSED++)) || true
         if [[ "$VERBOSE" == true ]]; then
             log_success "Disabled services count: $service_count (>= 5)"
         fi
     else
-        ((TESTS_RUN++))
-        ((TESTS_FAILED++))
+        ((TESTS_RUN++)) || true
+        ((TESTS_FAILED++)) || true
         log_error "Disabled services count: $service_count (< 5)"
     fi
 }
@@ -567,6 +567,9 @@ test_input_validation() {
 test_cache_functions() {
     print_test_header "Cache Function Tests"
 
+    # Enable caching for these tests
+    USE_CACHE=true
+
     # Test init_cache creates directory
     init_cache
     assert_true '[[ -d "$CACHE_DIR" ]]' "init_cache creates cache directory"
@@ -614,13 +617,45 @@ test_cache_functions() {
     assert_not_equals "" "$age" "get_cache_age returns value"
 
     # Test cache TTL validation (cache should be valid with default TTL)
-    assert_true 'is_cache_valid 3600' "is_cache_valid returns true for fresh cache"
+    CACHE_TTL=3600
+    assert_true 'is_cache_valid' "is_cache_valid returns true for fresh cache"
 
     # Test is_cache_valid with zero TTL (should always be invalid)
-    assert_false 'is_cache_valid 0' "is_cache_valid returns false for zero TTL"
+    CACHE_TTL=0
+    assert_false 'is_cache_valid' "is_cache_valid returns false for zero TTL"
 
     # Clean up test cache
     rm -f "$CACHE_FILE" 2>/dev/null || true
+}
+
+# Test missing file error handling
+test_missing_file_handling() {
+    print_test_header "Missing File Error Handling Tests"
+
+    # Test that missing lib file causes exit code 1
+    local temp_dir
+    temp_dir=$(mktemp -d)
+
+    # Create a minimal script directory with a missing lib file
+    mkdir -p "${temp_dir}/lib"
+    cp "${PROJECT_DIR}/lib/config.sh" "${temp_dir}/lib/config.sh"
+    cp "${PROJECT_DIR}/lib/utils.sh" "${temp_dir}/lib/utils.sh"
+    # Intentionally omit checks.sh
+
+    cp "${PROJECT_DIR}/hardening-compliance-check.sh" "${temp_dir}/"
+    chmod +x "${temp_dir}/hardening-compliance-check.sh"
+
+    local missing_lib_output
+    missing_lib_output=$("${temp_dir}/hardening-compliance-check.sh" --help 2>&1 || true)
+    assert_true '[[ "$missing_lib_output" == *"not found"* || "$missing_lib_output" == *"FAIL"* ]]' "Missing lib file produces error message"
+
+    # Clean up
+    rm -rf "$temp_dir"
+
+    # Test output to nonexistent directory (use --no-color and a single category for speed)
+    local nonexistent_dir_output
+    nonexistent_dir_output=$("${PROJECT_DIR}/hardening-compliance-check.sh" --no-color -c file_permissions -o /nonexistent/path/output.json -f json 2>&1 || true)
+    assert_true '[[ "$nonexistent_dir_output" == *"not exist"* || "$nonexistent_dir_output" == *"not writable"* || "$nonexistent_dir_output" == *"Failed to write"* ]]' "Output to nonexistent directory produces error"
 }
 
 # Test cache CLI options
@@ -727,6 +762,7 @@ main() {
     test_benchmark_coverage
     test_input_validation
     test_cache_functions
+    test_missing_file_handling
     test_cache_cli
 
     # Print summary


### PR DESCRIPTION
Added validation to verify required library files exist before sourcing them, preventing obscure errors when the `lib/` directory is incomplete or files are unreadable. Fixed arithmetic expansion failures under `set -e` by adding `|| true` to all counter increments across checks and tests. Added graceful early exits for missing system files like `/etc/shadow`, `/etc/passwd`, and sysctl config, so checks skip cleanly instead of crashing. Improved output file handling by validating the target directory exists and is writable before attempting writes, and added a test suite covering these failure scenarios. closes #8